### PR TITLE
Fix typing for get_reverse_action

### DIFF
--- a/gridworld/utils.py
+++ b/gridworld/utils.py
@@ -34,7 +34,7 @@ class Step(NamedTuple):
     new_state: tuple[int, int]
     done: bool
 
-    def get_reverse_action(self) -> "Step":
+    def get_reverse_action(self) -> "Step | None":
         if self.start == self.new_state:
             return None
         reverse_actions = {


### PR DESCRIPTION
## Summary
- correct return annotation for `get_reverse_action`

## Testing
- `pytest gridworld/tests/test_step.py -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_683f61778e848332a0fa61b59319f9e8