### PR TITLE
Fix output folder names in gridworld scripts

### DIFF
--- a/gridworld/scripts/empty_grid/grid_size.py
+++ b/gridworld/scripts/empty_grid/grid_size.py
@@ -14,7 +14,7 @@ from gridworld.runner import Runner
 
 console = Console()
 
-folder = f"output/gridworld-learing-by-grid-size"
+folder = f"output/gridworld-learning-by-grid-size"
 output_file = f"{folder}/output.md"
 
 if os.path.exists(folder):

--- a/gridworld/scripts/empty_grid/learning_over_time.py
+++ b/gridworld/scripts/empty_grid/learning_over_time.py
@@ -16,7 +16,7 @@ from gridworld.runner import Runner
 
 console = Console()
 
-folder = f"output/gridworld-learing-history"
+folder = f"output/gridworld-learning-history"
 output_file = f"{folder}/output.md"
 
 if os.path.exists(folder):

--- a/gridworld/scripts/empty_grid/max_steps.py
+++ b/gridworld/scripts/empty_grid/max_steps.py
@@ -14,7 +14,7 @@ from gridworld.runner import Runner
 
 console = Console()
 
-folder = f"output/gridworld-learing-by-steps"
+folder = f"output/gridworld-learning-by-steps"
 output_file = f"{folder}/output.md"
 
 if os.path.exists(folder):


### PR DESCRIPTION
## Summary
- fix typos in output folder names for empty grid analysis scripts

## Testing
- `pytest -q`
- `python -m gridworld.scripts.empty_grid.learning_over_time` *(fails: ModuleNotFoundError: matplotlib)*
- `python -m gridworld.scripts.empty_grid.max_steps` *(fails: ModuleNotFoundError: matplotlib)*
- `python -m gridworld.scripts.empty_grid.grid_size` *(fails: ModuleNotFoundError: matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_683f61bad5748332a7da92c18682ed71