### PR TITLE
Fix grid test name to run in pytest

### DIFF
--- a/gridworld/components/tests/test_grid.py
+++ b/gridworld/components/tests/test_grid.py
@@ -438,7 +438,7 @@ class TestStep:
 
         assert env.visit_counts == {(1, 0): 1, (0, 0): 2}
 
-    def adds_visit_count_when_walking_into_obstacle(self):
+    def test_adds_visit_count_when_walking_into_obstacle(self):
         env = GridWorldEnv()
         env.agent_pos = (0, 0)
         action = "up"


### PR DESCRIPTION
## Summary
- rename `adds_visit_count_when_walking_into_obstacle` to
  `test_adds_visit_count_when_walking_into_obstacle`
- run the test suite (fails due to missing dependencies)

## Testing
- `pytest -k test_adds_visit_count_when_walking_into_obstacle -vv | head -n 20` *(fails: ImportError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_683f61dea9c083329bfedf6792165fe2