### PR TITLE
Fix utils optional imports

### DIFF
--- a/gridworld/utils.py
+++ b/gridworld/utils.py
@@ -1,4 +1,3 @@
-from re import L
 from typing import NamedTuple, TypedDict
 
 from matplotlib import pyplot as plt


### PR DESCRIPTION
## Summary
- revert optional import guards in gridworld.utils
- drop stray unused import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_683f60d26cf083329f90e16556f5dae1