### PR TITLE
Fix q_table defaults to floats

### DIFF
--- a/gridworld/agents/q_learning_agent.py
+++ b/gridworld/agents/q_learning_agent.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from email.policy import default
 from random import Random
 from gridworld.agents.generic_agent import Agent
 from gridworld.utils import SIMPLE_ACTIONS, Step
@@ -8,7 +7,9 @@ from gridworld.utils import SIMPLE_ACTIONS, Step
 class QLearningAgent(Agent):
     def __init__(self, *, rng: Random | None = None, **kwargs):
         self.actions = SIMPLE_ACTIONS
-        self.q_table = defaultdict(lambda: {action: 0 for action in self.actions})
+        self.q_table: defaultdict[tuple[int, int], dict[str, float]] = defaultdict(
+            lambda: {action: 0.0 for action in self.actions}
+        )
         # exploration rate
         self.epsilon = 0.1
         # learning rate (how fast Q-values update)

--- a/gridworld/agents/tests/test_q_learning_agent.py
+++ b/gridworld/agents/tests/test_q_learning_agent.py
@@ -8,7 +8,7 @@ class TestAct:
         rng = mocker.Mock()
         rng.random.return_value = 0.05
         agent = QLearningAgent(rng=rng)
-        agent.q_table = {(0, 0): {UP: 0, DOWN: 1, LEFT: 1, RIGHT: 0}}
+        agent.q_table = {(0, 0): {UP: 0.0, DOWN: 1.0, LEFT: 1.0, RIGHT: 0.0}}
         agent.act((0, 0))
         rng.choice.assert_called_once_with(agent.actions)
 
@@ -16,14 +16,14 @@ class TestAct:
         rng = mocker.Mock()
         rng.random.return_value = 0.2
         agent = QLearningAgent(rng=rng)
-        agent.q_table = {(0, 0): {UP: 0, DOWN: 1, LEFT: 1, RIGHT: 0}}
+        agent.q_table = {(0, 0): {UP: 0.0, DOWN: 1.0, LEFT: 1.0, RIGHT: 0.0}}
         agent.act((0, 0))
         rng.choice.assert_called_once_with([DOWN, LEFT])
 
     def test_returns_an_action_with_max_q_value(self, mocker):
         rng = random.Random(42)
         agent = QLearningAgent(rng=rng)
-        agent.q_table = {(0, 0): {UP: 1, DOWN: 0, LEFT: 0, RIGHT: 0}}
+        agent.q_table = {(0, 0): {UP: 1.0, DOWN: 0.0, LEFT: 0.0, RIGHT: 0.0}}
         action = agent.act((0, 0))
         assert action == UP
 
@@ -31,7 +31,7 @@ class TestAct:
 class TestReset:
     def test_do_not_reset_q_table(self):
         agent = QLearningAgent()
-        old_table = {(0, 0): {UP: 1, DOWN: 0, LEFT: 0, RIGHT: 0}}
+        old_table = {(0, 0): {UP: 1.0, DOWN: 0.0, LEFT: 0.0, RIGHT: 0.0}}
         agent.q_table = old_table
         agent.reset()
         assert isinstance(agent.q_table, dict)
@@ -41,7 +41,7 @@ class TestReset:
 class TestObserve:
     def test_initial_q_table_update(self):
         agent = QLearningAgent()
-        agent.q_table[(0, 0)] = {UP: 0, DOWN: 0, LEFT: 0, RIGHT: 0}
+        agent.q_table[(0, 0)] = {UP: 0.0, DOWN: 0.0, LEFT: 0.0, RIGHT: 0.0}
         step = Step(
             start=(0, 0),
             action=UP,
@@ -51,12 +51,12 @@ class TestObserve:
         )
         agent.observe(step)
         assert agent.q_table == {
-            (0, 0): {UP: -1, DOWN: 0, LEFT: 0, RIGHT: 0},
+            (0, 0): {UP: -1.0, DOWN: 0.0, LEFT: 0.0, RIGHT: 0.0},
         }
 
     def test_handles_more_information_if_it_knows_something_already(self):
         agent = QLearningAgent()
-        agent.q_table[(0, 0)] = {UP: -6, DOWN: 0, LEFT: 0, RIGHT: 0}
+        agent.q_table[(0, 0)] = {UP: -6.0, DOWN: 0.0, LEFT: 0.0, RIGHT: 0.0}
         step = Step(
             start=(0, 0),
             action=UP,
@@ -66,13 +66,13 @@ class TestObserve:
         )
         agent.observe(step)
         assert agent.q_table == {
-            (0, 0): {UP: -6.4, DOWN: 0, LEFT: 0, RIGHT: 0},
-            (0, 1): {UP: 0, DOWN: 0, LEFT: 0, RIGHT: 0},
+            (0, 0): {UP: -6.4, DOWN: 0.0, LEFT: 0.0, RIGHT: 0.0},
+            (0, 1): {UP: 0.0, DOWN: 0.0, LEFT: 0.0, RIGHT: 0.0},
         }
 
     def test_updates_if_already_at_score(self):
         agent = QLearningAgent()
-        agent.q_table[(0, 0)] = {UP: -10, DOWN: 0, LEFT: 0, RIGHT: 0}
+        agent.q_table[(0, 0)] = {UP: -10.0, DOWN: 0.0, LEFT: 0.0, RIGHT: 0.0}
         step = Step(
             start=(0, 0),
             action=UP,
@@ -82,12 +82,12 @@ class TestObserve:
         )
         agent.observe(step)
         assert agent.q_table == {
-            (0, 0): {UP: -10, DOWN: 0, LEFT: 0, RIGHT: 0},
+            (0, 0): {UP: -10.0, DOWN: 0.0, LEFT: 0.0, RIGHT: 0.0},
         }
 
     def test_updates_for_next_location_score(self):
         agent = QLearningAgent()
-        agent.q_table[(1, 0)] = {UP: 0, DOWN: 0, LEFT: 10, RIGHT: 0}
+        agent.q_table[(1, 0)] = {UP: 0.0, DOWN: 0.0, LEFT: 10.0, RIGHT: 0.0}
         step = Step(
             start=(0, 0),
             action=DOWN,
@@ -97,13 +97,13 @@ class TestObserve:
         )
         agent.observe(step)
         assert agent.q_table == {
-            (0, 0): {UP: 0, DOWN: 0.8, LEFT: 0, RIGHT: 0},
-            (1, 0): {UP: 0, DOWN: 0, LEFT: 10, RIGHT: 0},
+            (0, 0): {UP: 0.0, DOWN: 0.8, LEFT: 0.0, RIGHT: 0.0},
+            (1, 0): {UP: 0.0, DOWN: 0.0, LEFT: 10.0, RIGHT: 0.0},
         }
 
     def test_next_best_choice_is_negative(self):
         agent = QLearningAgent()
-        agent.q_table[(1, 0)] = {UP: -10, DOWN: -1, LEFT: -10, RIGHT: -1}
+        agent.q_table[(1, 0)] = {UP: -10.0, DOWN: -1.0, LEFT: -10.0, RIGHT: -1.0}
         step = Step(
             start=(0, 0),
             action=DOWN,
@@ -113,6 +113,6 @@ class TestObserve:
         )
         agent.observe(step)
         assert agent.q_table == {
-            (0, 0): {UP: 0, DOWN: -0.19, LEFT: 0, RIGHT: 0},
-            (1, 0): {UP: -10, DOWN: -1, LEFT: -10, RIGHT: -1},
+            (0, 0): {UP: 0.0, DOWN: -0.19, LEFT: 0.0, RIGHT: 0.0},
+            (1, 0): {UP: -10.0, DOWN: -1.0, LEFT: -10.0, RIGHT: -1.0},
         }


### PR DESCRIPTION
## Summary
- update default q_table initialization to use floats
- type q_table as defaultdict[(int, int), dict[str, float]]
- adjust unit tests for float values

## Testing
- `pytest -q` *(fails: TestStep.test_adds_visit_count_when_walking_into_obstacle)*

------
https://chatgpt.com/codex/tasks/task_e_6848b533cb08833296f8a5ba5c18a483