### PR TITLE
Enable strict type checking

### DIFF
--- a/gridworld/agents/manhattan_agent.py
+++ b/gridworld/agents/manhattan_agent.py
@@ -23,7 +23,7 @@ class ManhattanAgent(Agent):
         row_goal, col_goal = self.goal
 
         # Preferred directions (Manhattan-style)
-        preferred = []
+        preferred: list[str] = []
         if row < row_goal:
             preferred.append(DOWN)
         if row > row_goal:
@@ -33,8 +33,8 @@ class ManhattanAgent(Agent):
         if col > col_goal:
             preferred.append(LEFT)
 
-        tried = self._tried.get(state, set())
-        options = [a for a in preferred if a not in tried]
+        tried: MutableSet[str] = self._tried.get(state, set())
+        options: list[str] = [a for a in preferred if a not in tried]
 
         # Fallback to any untried direction
         if not options:

--- a/gridworld/components/grid_environment.py
+++ b/gridworld/components/grid_environment.py
@@ -44,6 +44,7 @@ Example usage:
 """
 
 from collections import defaultdict
+from collections.abc import ItemsView, ValuesView
 from dataclasses import dataclass
 from unittest.mock import ANY
 from rich.console import Console
@@ -102,13 +103,15 @@ class StepResult:
 
 
 class VisitCounter:
-    def __init__(self, data: dict = None) -> None:
-        self.data = data or defaultdict(int)
+    def __init__(
+        self, data: dict[tuple[int, int], int] | None = None
+    ) -> None:
+        self.data: dict[tuple[int, int], int] = data or defaultdict(int)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: tuple[int, int]) -> int:
         return self.data[key]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: tuple[int, int], value: int) -> None:
         self.data[key] = value
 
     def __eq__(self, value: "dict | VisitCounter") -> bool:
@@ -153,10 +156,10 @@ class VisitCounter:
             new_counter[coordinate] = avg
         return new_counter
 
-    def items(self):
+    def items(self) -> 'ItemsView[tuple[int, int], int]':
         return self.data.items()
 
-    def values(self):
+    def values(self) -> 'ValuesView[int]':
         return self.data.values()
 
 

--- a/gridworld/runner.py
+++ b/gridworld/runner.py
@@ -89,7 +89,7 @@ class Runner:
         clear_render: bool = False,
         sleep: float = 0.5,
     ) -> list[RunnerReturn]:
-        results = []
+        results: list[RunnerReturn] = []
         for _ in range(num_episodes):
             result = self.run_episode(
                 render=render, clear_render=clear_render, sleep=sleep

--- a/gridworld/utils.py
+++ b/gridworld/utils.py
@@ -1,3 +1,4 @@
+# pyright: reportUnknownMemberType=false
 from typing import NamedTuple, TypedDict
 
 from matplotlib import pyplot as plt

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,5 @@
 {
-  "typeCheckingMode": "basic",
+  "typeCheckingMode": "strict",
   "reportMissingReturnType": "error",
   "reportMissingParameterType": true,
   "reportUnknownParameterType": true,


### PR DESCRIPTION
## Summary
- switch pyright to strict mode
- add type hints to `ManhattanAgent`
- refine `VisitCounter` types
- annotate `Runner.run_episodes`
- silence matplotlib unknown member warnings

## Testing
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497befa2c483328bdddd8ec2ee7bd9