### PR TITLE
style: run black formatting

### DIFF
--- a/gridworld/agents/lost_agent.py
+++ b/gridworld/agents/lost_agent.py
@@ -37,8 +37,8 @@ class LostAgent(Agent):
             # Increment the count for the reverse action as well
 
     def reset(self, **kwargs: Any) -> None:
-        self.previous_attempts: defaultdict[tuple[int, int], dict[str, int]] = defaultdict(
-            lambda: {action: 0 for action in SIMPLE_ACTIONS}
+        self.previous_attempts: defaultdict[tuple[int, int], dict[str, int]] = (
+            defaultdict(lambda: {action: 0 for action in SIMPLE_ACTIONS})
         )
 
 

--- a/gridworld/components/grid_environment.py
+++ b/gridworld/components/grid_environment.py
@@ -103,9 +103,7 @@ class StepResult:
 
 
 class VisitCounter:
-    def __init__(
-        self, data: dict[tuple[int, int], int] | None = None
-    ) -> None:
+    def __init__(self, data: dict[tuple[int, int], int] | None = None) -> None:
         self.data: dict[tuple[int, int], int] = data or defaultdict(int)
 
     def __getitem__(self, key: tuple[int, int]) -> int:
@@ -156,10 +154,10 @@ class VisitCounter:
             new_counter[coordinate] = avg
         return new_counter
 
-    def items(self) -> 'ItemsView[tuple[int, int], int]':
+    def items(self) -> "ItemsView[tuple[int, int], int]":
         return self.data.items()
 
-    def values(self) -> 'ValuesView[int]':
+    def values(self) -> "ValuesView[int]":
         return self.data.values()
 
 

--- a/gridworld/scripts/empty_grid/learning_over_time.py
+++ b/gridworld/scripts/empty_grid/learning_over_time.py
@@ -53,7 +53,9 @@ summaries = []
 NUMBER_OF_EPISODES_PER_ITERATION = 30
 
 
-def run_test(env: GridWorldEnv, agent: QLearningAgent, iteration: int, render: bool = False) -> None:
+def run_test(
+    env: GridWorldEnv, agent: QLearningAgent, iteration: int, render: bool = False
+) -> None:
     runner = Runner(env, agent)
     results = runner.run_episodes(NUMBER_OF_EPISODES_PER_ITERATION, render=False)
     analysis = runner.analyze_results(results)

--- a/tic_tac_logic/tests/agents/test_mask_agent.py
+++ b/tic_tac_logic/tests/agents/test_mask_agent.py
@@ -767,8 +767,12 @@ class TestAct:
     def test_returns_best_option_when_available(self, mocker):
         grid = [[E, E], [E, E]]
         agent = MaskAgent(2, 2)
-        mocker.patch.object(MaskAgent, "do_not_discover", autospec=True, return_value=True)
-        mocker.patch.object(MaskAgent, "find_aggressive_failures", autospec=True, return_value=set())
+        mocker.patch.object(
+            MaskAgent, "do_not_discover", autospec=True, return_value=True
+        )
+        mocker.patch.object(
+            MaskAgent, "find_aggressive_failures", autospec=True, return_value=set()
+        )
         mocker.patch.object(
             MaskAgent,
             "remove_failing_options",
@@ -781,8 +785,19 @@ class TestAct:
         grid = [[E, E], [E, E]]
         agent = MaskAgent(2, 2)
         random.seed(0)
-        mocker.patch.object(MaskAgent, "do_not_discover", autospec=True, return_value=True)
-        mocker.patch.object(MaskAgent, "find_aggressive_failures", autospec=True, return_value=set())
-        mocker.patch.object(MaskAgent, "remove_failing_options", autospec=True, side_effect=lambda self, g, pm, fm: pm)
-        mocker.patch.object(MaskAgent, "options_with_one_choice", autospec=True, return_value=set())
+        mocker.patch.object(
+            MaskAgent, "do_not_discover", autospec=True, return_value=True
+        )
+        mocker.patch.object(
+            MaskAgent, "find_aggressive_failures", autospec=True, return_value=set()
+        )
+        mocker.patch.object(
+            MaskAgent,
+            "remove_failing_options",
+            autospec=True,
+            side_effect=lambda self, g, pm, fm: pm,
+        )
+        mocker.patch.object(
+            MaskAgent, "options_with_one_choice", autospec=True, return_value=set()
+        )
         assert agent.act(Observation(grid)) == ((1, 1), "O")


### PR DESCRIPTION
## Summary
- run `black` to fix formatting

## Testing
- `pyright`
- `flake8 | head -n 20` *(fails: E704, F401, F811, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a034ca3f083329ea8b3d2802ffda6