### PR TITLE
test: move failure agent reset check

### DIFF
--- a/gridworld/agents/q_learning_agent.py
+++ b/gridworld/agents/q_learning_agent.py
@@ -40,6 +40,7 @@ class QLearningAgent(Agent):
         return self.rng.choice(best_actions)
 
     def reset(self) -> None:
+        """Clear any episodic state while preserving the Q-table and exploration settings."""
         pass
 
     def observe(self, step: Step) -> None:

--- a/tic_tac_logic/agents/failure_learning_agent.py
+++ b/tic_tac_logic/agents/failure_learning_agent.py
@@ -178,5 +178,5 @@ class FailureAgent(Agent):
                 q_table["failures"].add(move)
 
     def reset(self) -> None:
-        # Reset the agent's state
-        ...
+        """Intentionally left blank as the agent maintains no episodic state."""
+        pass

--- a/tic_tac_logic/tests/agents/test_failure_agent.py
+++ b/tic_tac_logic/tests/agents/test_failure_agent.py
@@ -298,3 +298,14 @@ class TestGetValidPlacements:
         assert len(agent.get_valid_placements(grid.grid)) == 70
         grid.reset()
         assert len(agent.get_valid_placements(grid.grid)) == 71
+
+
+class TestReset:
+    def test_does_not_modify_failures(self) -> None:
+        agent = FailureAgent(3, 3)
+        move = Move.create(FailureClass.ROW, "X, X, O", 1, "X")
+        agent.q_table["failures"] = {move}
+
+        agent.reset()
+
+        assert agent.q_table["failures"] == {move}


### PR DESCRIPTION
## Summary
- keep Q-table and exploration settings when resetting QLearningAgent
- clarify that FailureAgent.reset does nothing
- move reset behavior test into existing suite

## Testing
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849e2ca9f748332afd1e689d8eaf804