### PR TITLE
test: add reinforcement agent regression tests

### DIFF
--- a/queens/agents/tests/reinforcement_agents/test_decay_failing_paths.py
+++ b/queens/agents/tests/reinforcement_agents/test_decay_failing_paths.py
@@ -1,0 +1,22 @@
+import random
+from collections import defaultdict
+
+from queens.agents.reinforcement_agents import DecayFailingPaths
+from queens.utils import build_board_array
+
+board = build_board_array([])
+
+
+class TestRebuildScores:
+    def test_applies_failure_penalty(self):
+        rng = random.Random(1)
+        agent = DecayFailingPaths(rng=rng)
+        path_one = [(0, 0), (1, 1)]
+        path_two = [(2, 2), (3, 3), (4, 4)]
+        agent.best_options = defaultdict(list, {5: [path_one], 7: [path_two]})
+        agent.failing_paths[tuple(path_one)] = 2
+        scores = agent._rebuild_scores()
+        expected_one = 5 - (1 + 2) * (1 - len(path_one) / 8)
+        expected_two = 7 - (1 + 0) * (1 - len(path_two) / 8)
+        assert scores[expected_one] == [path_one]
+        assert scores[expected_two] == [path_two]

--- a/queens/agents/tests/reinforcement_agents/test_dynamic_epsilon_agent.py
+++ b/queens/agents/tests/reinforcement_agents/test_dynamic_epsilon_agent.py
@@ -1,0 +1,57 @@
+import random
+
+import pytest
+import numpy as np
+
+from queens.agents.reinforcement_agents import DynamicEpsilonAgent
+from queens.dtos import StepResult, RunnerReturn
+from queens.utils import build_board_array
+
+board = build_board_array([])
+
+
+class TestEpsilonFinalIncrease:
+    def test_returns_scaled_value(self):
+        agent = DynamicEpsilonAgent(epsilon=0.2, epsilon_increase=1.5)
+        assert agent.epsilon_final_increase() == pytest.approx(0.2 * 1.5)
+
+
+class TestObserveResult:
+    def test_updates_on_success(self):
+        rng = random.Random(1)
+        agent = DynamicEpsilonAgent(
+            rng=rng, epsilon=0.5, epsilon_decay=0.5, epsilon_min=0.1
+        )
+        agent.observe_result(
+            RunnerReturn(
+                trajectory=[StepResult(action=(0, 0))],
+                solved=True,
+                board=np.array([[0]]),
+                moves=1,
+                score=100,
+            )
+        )
+        assert agent.epsilon == pytest.approx(max(0.1, 0.5 * 0.5))
+        assert agent.failure_count == 0
+        assert agent.last_failure_minus_one == []
+
+    def test_updates_on_failure(self):
+        rng = random.Random(2)
+        agent = DynamicEpsilonAgent(
+            rng=rng,
+            epsilon=0.2,
+            epsilon_increase=1.5,
+            epsilon_max=0.5,
+        )
+        agent.observe_result(
+            RunnerReturn(
+                trajectory=[StepResult(action=(0, 0))],
+                solved=False,
+                board=np.array([[0]]),
+                moves=1,
+                score=-1,
+            )
+        )
+        expected = min(0.5, 0.2 * 1.5)
+        assert agent.epsilon == pytest.approx(expected)
+        assert agent.failure_count == 1


### PR DESCRIPTION
## Summary
- add tests for DecayFailingPaths `_rebuild_scores`
- verify DynamicEpsilonAgent epsilon update logic

## Testing
- `pyright`
- `black --check -q queens/agents/tests/reinforcement_agents/test_decay_failing_paths.py queens/agents/tests/reinforcement_agents/test_dynamic_epsilon_agent.py`
- `flake8 queens/agents/tests/reinforcement_agents/test_decay_failing_paths.py queens/agents/tests/reinforcement_agents/test_dynamic_epsilon_agent.py`
- `pytest queens/agents/tests/reinforcement_agents/test_decay_failing_paths.py queens/agents/tests/reinforcement_agents/test_dynamic_epsilon_agent.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a07298e1c8332b051514c708e3c17