### PR TITLE
Handle invalid input in AlgorithmicAgent._opposite

### DIFF
--- a/tic_tac_logic/agents/algorithmic_agent.py
+++ b/tic_tac_logic/agents/algorithmic_agent.py
@@ -24,6 +24,8 @@ class AlgorithmicAgent(BaseAgent):
         pass
 
     def _opposite(self, symbol: str) -> str:
+        if symbol not in (X, O):
+            raise ValueError("_opposite called with invalid symbol")
         return O if symbol == X else X
 
     def _deduce_one_move(self, grid: list[list[str]]) -> tuple[int, int] | None:

--- a/tic_tac_logic/tests/agents/test_algorithmic_agent_misc.py
+++ b/tic_tac_logic/tests/agents/test_algorithmic_agent_misc.py
@@ -1,13 +1,19 @@
+import pytest
+
 from tic_tac_logic.agents.algorithmic_agent import AlgorithmicAgent
 from tic_tac_logic.constants import X, O, E
 
 
 class TestOpposite:
-    def test_returns_opposite_symbol(self) -> None:
+    @pytest.mark.parametrize("symbol,expected", [(X, O), (O, X)])
+    def test_returns_opposite_symbol(self, symbol: str, expected: str) -> None:
         agent = AlgorithmicAgent(rows=2, columns=2)
-        assert agent._opposite(X) == O
-        assert agent._opposite(O) == X
-        assert agent._opposite(E) == X
+        assert agent._opposite(symbol) == expected
+
+    def test_raises_error_on_invalid_symbol(self) -> None:
+        agent = AlgorithmicAgent(rows=2, columns=2)
+        with pytest.raises(ValueError):
+            agent._opposite(E)
 
 
 class TestDeduceOneMove:


### PR DESCRIPTION
## Summary
- validate symbol in `_opposite` and raise `ValueError`
- refactor `_opposite` tests with parameterization and explicit invalid case

## Testing
- `black tic_tac_logic/tests/agents/test_algorithmic_agent_misc.py`
- `flake8`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a08f3dee48332ac44f420e5986e6e