### PR TITLE
test: expand mask agent coverage

### DIFF
--- a/tic_tac_logic/tests/agents/test_mask_agent.py
+++ b/tic_tac_logic/tests/agents/test_mask_agent.py
@@ -727,6 +727,99 @@ class TestRemovePossibleMoves:
             ((1, 3), O),
         }
 
+    @pytest.mark.parametrize(
+        "possible_moves,failure_masks,expected",
+        [
+            (
+                {((0, 0), X)},
+                set(),
+                {((0, 0), X)},
+            ),
+            (
+                {
+                    ((0, 0), X),
+                    ((0, 1), O),
+                    ((0, 1), X),
+                    ((1, 2), X),
+                    ((1, 2), O),
+                    ((1, 3), O),
+                },
+                {
+                    ConfidentMask(
+                        mask_key=MaskKey(
+                            mask_type=MaskHorizontal3Centered,
+                            pattern="X__",
+                            symbol="O",
+                        ),
+                        prediction=-1.0,
+                    ),
+                    ConfidentMask(
+                        mask_key=MaskKey(
+                            mask_type=MaskHorizontal3CenteredO,
+                            pattern="___",
+                            symbol="O",
+                        ),
+                        prediction=-1.0,
+                    ),
+                },
+                {
+                    ((0, 0), X),
+                    ((0, 1), X),
+                    ((1, 2), X),
+                    ((1, 3), O),
+                },
+            ),
+            (
+                {((1, 2), O), ((1, 2), X)},
+                {
+                    ConfidentMask(
+                        mask_key=MaskKey(
+                            mask_type=MaskHorizontal3Centered,
+                            pattern="X__",
+                            symbol="O",
+                        ),
+                        prediction=-1.0,
+                    ),
+                    ConfidentMask(
+                        mask_key=MaskKey(
+                            mask_type=MaskHorizontal3Centered,
+                            pattern="X__",
+                            symbol="X",
+                        ),
+                        prediction=-1.0,
+                    ),
+                },
+                set(),
+            ),
+            (
+                {((9, 0), X), ((0, 0), X)},
+                {
+                    ConfidentMask(
+                        mask_key=MaskKey(
+                            mask_type=MaskHorizontal3Centered,
+                            pattern="X__",
+                            symbol="X",
+                        ),
+                        prediction=-1.0,
+                    ),
+                },
+                {((9, 0), X), ((0, 0), X)},
+            ),
+        ],
+    )
+    def test_remove_failing_options_parametrized(
+        self,
+        possible_moves: set[tuple[tuple[int, int], str]],
+        failure_masks: set[ConfidentMask],
+        expected: set[tuple[tuple[int, int], str]],
+    ) -> None:
+        grid = get_easy_grid()
+        agent = MaskAgent(len(grid), len(grid[0]))
+        assert (
+            agent.remove_failing_options(grid, possible_moves, failure_masks)
+            == expected
+        )
+
 
 class TestOptionsWithOneChoice:
     def test_returns_options_with_one_choice(self):

--- a/tic_tac_logic/tests/agents/test_masks.py
+++ b/tic_tac_logic/tests/agents/test_masks.py
@@ -1,8 +1,11 @@
+import pytest
 from tic_tac_logic.agents.masks import (
     generate_pool_masks,
     MaskRules,
     AbstractMask,
+    MaskKey,
 )
+from tic_tac_logic.constants import X, O, E
 
 
 class TestGeneratePoolMasks:
@@ -336,3 +339,59 @@ class TestGeneratePoolMasks:
                 ),
             ),
         ]
+
+
+class TestMaskRules:
+    @pytest.mark.parametrize(
+        "coord, expected",
+        [
+            ((1, 1), [[X, O, E], [O, E, X], [E, X, O]]),
+            ((0, 1), None),
+            ((2, 2), None),
+            ((1, 0), None),
+            ((1, 2), None),
+        ],
+    )
+    def test_get_pattern(
+        self, coord: tuple[int, int], expected: list[list[str]] | None
+    ) -> None:
+        rule = MaskRules(1, 1, 1, 1)
+        grid = [
+            [X, O, E],
+            [O, E, X],
+            [E, X, O],
+        ]
+        assert rule.get_pattern(coord, grid) == expected
+
+
+class TestAbstractMask:
+    def test_remove_non_matching(self) -> None:
+        mask = AbstractMask(match_symbol=X, rule=MaskRules(0, 0, 0, 0))
+        grid = [[X, O], [E, X]]
+        assert mask.remove_non_matching(grid) == [[X, E], [E, X]]
+
+    def test_create_mask_key(self) -> None:
+        mask = AbstractMask(match_symbol=None, rule=MaskRules(0, 0, 0, 0))
+        value = [[X, E], [O, E]]
+        assert mask.create_mask_key(value, X) == MaskKey(
+            mask_type=mask, pattern="X_\nO_", symbol=X
+        )
+
+    @pytest.mark.parametrize(
+        "coord, expected",
+        [
+            (
+                (0, 0),
+                MaskKey(
+                    mask_type=AbstractMask(match_symbol=X, rule=MaskRules(0, 0, 0, 0)),
+                    pattern="X",
+                    symbol=X,
+                ),
+            ),
+            ((2, 0), None),
+        ],
+    )
+    def test_get_mask(self, coord: tuple[int, int], expected: MaskKey | None) -> None:
+        base_mask = AbstractMask(match_symbol=X, rule=MaskRules(0, 0, 0, 0))
+        grid = [[X, O], [E, X]]
+        assert base_mask.get_mask(coord, grid, current=X) == expected


### PR DESCRIPTION
## Summary
- parameterize remove_failing_options with multiple scenarios
- add tests for MaskRules and AbstractMask behavior

## Testing
- `pytest -q`
- `pyright`

------
https://chatgpt.com/codex/tasks/task_e_684a072c3f8c8332aeefa7a096e6d695