### PR TITLE
ci: add black format check

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,21 @@
+name: Black formatting check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run black
+        run: black --check .

--- a/tic_tac_logic/agents/algorithmic_agent.py
+++ b/tic_tac_logic/agents/algorithmic_agent.py
@@ -7,10 +7,10 @@ from tic_tac_logic.constants import X, O, E, Observation, StepResult
 class AlgorithmicAgent(BaseAgent):
     """
     Deterministic agent for solving Tic-Tac-Logic puzzles.
-    
-    This is an agent being used as a testing ground for the codex genai coding agent. 
-    
-    I am aware it does not right now include all the rules, we are working on getting it to a good place 
+
+    This is an agent being used as a testing ground for the codex genai coding agent.
+
+    I am aware it does not right now include all the rules, we are working on getting it to a good place
     """
 
     def act(self, observation: Observation) -> tuple[tuple[int, int], str]:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `black --check`

## Testing
- `flake8`
- `black --check .` *(fails: would reformat 4 files)*
- `pyright`
- `pytest -q`
- `coverage run -m pytest -q && coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_684a0f34d85c83328cceb549b28797e0